### PR TITLE
Refactor excel input boxes in menu2.tsx

### DIFF
--- a/client/src/components/excel_clipboard_box.tsx
+++ b/client/src/components/excel_clipboard_box.tsx
@@ -14,26 +14,68 @@ function sanitizeExcelHtmlToSingleTable(rawHtml: string): string | null {
     const parser = new DOMParser();
     const doc = parser.parseFromString(rawHtml, "text/html");
 
-    // Remove global-affecting tags
-    doc.querySelectorAll("style, link, meta, script, xml").forEach((el) => el.remove());
-
     // Prefer the first table inside the fragment
     const table = doc.querySelector("table");
     if (!table) return null;
 
-    // Clone to detach from source document
+    // Clone to detach from source document and preserve classes/styles for computed style inlining
     const tableClone = table.cloneNode(true) as HTMLElement;
 
-    // Remove ids/classes that could collide across pastes
-    const elements = [tableClone, ...Array.from(tableClone.querySelectorAll("*"))] as HTMLElement[];
-    for (const el of elements) {
+    // Build a hidden sandbox to compute styles (include any <style> from source)
+    const sandbox = document.createElement("div");
+    sandbox.style.position = "fixed";
+    sandbox.style.left = "-99999px";
+    sandbox.style.top = "-99999px";
+    sandbox.style.visibility = "hidden";
+    // Append source <style> tags to sandbox for accurate computed styles
+    const sourceStyles = Array.from(doc.querySelectorAll("style"));
+    for (const s of sourceStyles) {
+      const styleEl = document.createElement("style");
+      styleEl.textContent = s.textContent || "";
+      sandbox.appendChild(styleEl);
+    }
+    // Append the cloned table with its class-based styling intact
+    sandbox.appendChild(tableClone);
+    document.body.appendChild(sandbox);
+
+    // Inline a curated set of computed styles to preserve Excel formatting
+    const inlineTargets = [tableClone, ...Array.from(tableClone.querySelectorAll("*"))] as HTMLElement[];
+    const styleProps = [
+      // borders
+      "borderTop", "borderRight", "borderBottom", "borderLeft", "borderCollapse",
+      // background & text
+      "backgroundColor", "color", "fontWeight", "fontStyle", "textDecoration",
+      // font
+      "fontSize", "fontFamily",
+      // alignment
+      "textAlign", "verticalAlign", "whiteSpace",
+      // spacing & size
+      "paddingTop", "paddingRight", "paddingBottom", "paddingLeft",
+      "width", "height"
+    ] as const;
+
+    for (const el of inlineTargets) {
+      const cs = getComputedStyle(el);
+      let styleText = el.getAttribute("style") || "";
+      for (const prop of styleProps) {
+        const value = (cs as any)[prop];
+        if (value) {
+          // Convert camelCase to kebab-case for CSS property names
+          const kebab = prop.replace(/[A-Z]/g, m => "-" + m.toLowerCase());
+          styleText += `${kebab}:${value};`;
+        }
+      }
+      el.setAttribute("style", styleText);
+      // Remove ids/classes to avoid collisions in composed content
       el.removeAttribute("id");
       el.removeAttribute("class");
-      // Keep inline styles from Excel; they are scoped within shadow DOM
     }
 
     // Ensure table renders cleanly; allow natural width so horizontal scroll can appear
     tableClone.style.borderCollapse = tableClone.style.borderCollapse || "collapse";
+
+    // Cleanup sandbox
+    document.body.removeChild(sandbox);
 
     return tableClone.outerHTML;
   } catch (e) {

--- a/client/src/components/excel_clipboard_box.tsx
+++ b/client/src/components/excel_clipboard_box.tsx
@@ -32,8 +32,7 @@ function sanitizeExcelHtmlToSingleTable(rawHtml: string): string | null {
       // Keep inline styles from Excel; they are scoped within shadow DOM
     }
 
-    // Ensure table is visible within the box
-    tableClone.style.maxWidth = "100%";
+    // Ensure table renders cleanly; allow natural width so horizontal scroll can appear
     tableClone.style.borderCollapse = tableClone.style.borderCollapse || "collapse";
 
     return tableClone.outerHTML;
@@ -116,7 +115,7 @@ export default function ExcelClipboardBox({ value, onChange, placeholder, classN
 
   return (
     <div
-      className={`relative rounded-md border-2 border-dashed border-slate-300 min-h-32 px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-ring ${className || ""}`}
+      className={`relative rounded-md border-2 border-dashed border-slate-300 min-h-32 px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-ring overflow-x-auto ${className || ""}`}
       onPaste={handlePaste}
       onKeyDown={handleKeyDown}
       onBeforeInput={handleBeforeInput as any}

--- a/client/src/components/excel_clipboard_box.tsx
+++ b/client/src/components/excel_clipboard_box.tsx
@@ -1,0 +1,143 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Table as TableIcon, FileSpreadsheet } from "lucide-react";
+
+interface ExcelClipboardBoxProps {
+  value: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+// Sanitize pasted HTML to a single table element and strip global-affecting tags
+function sanitizeExcelHtmlToSingleTable(rawHtml: string): string | null {
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(rawHtml, "text/html");
+
+    // Remove global-affecting tags
+    doc.querySelectorAll("style, link, meta, script, xml").forEach((el) => el.remove());
+
+    // Prefer the first table inside the fragment
+    const table = doc.querySelector("table");
+    if (!table) return null;
+
+    // Clone to detach from source document
+    const tableClone = table.cloneNode(true) as HTMLElement;
+
+    // Remove ids/classes that could collide across pastes
+    const elements = [tableClone, ...Array.from(tableClone.querySelectorAll("*"))] as HTMLElement[];
+    for (const el of elements) {
+      el.removeAttribute("id");
+      el.removeAttribute("class");
+      // Keep inline styles from Excel; they are scoped within shadow DOM
+    }
+
+    // Ensure table is visible within the box
+    tableClone.style.maxWidth = "100%";
+    tableClone.style.borderCollapse = tableClone.style.borderCollapse || "collapse";
+
+    return tableClone.outerHTML;
+  } catch (e) {
+    console.warn("Failed to sanitize Excel HTML:", e);
+    return null;
+  }
+}
+
+export default function ExcelClipboardBox({ value, onChange, placeholder, className }: ExcelClipboardBoxProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [shadowRootRef, setShadowRootRef] = useState<ShadowRoot | null>(null);
+
+  // Style scoped to shadow DOM to avoid leaking
+  const shadowStyles = useMemo(() => {
+    return `
+      <style>
+        :host { all: initial; }
+        .excel-container { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
+        table { width: max-content; border-collapse: collapse; }
+        td, th { border: 1px solid #e5e7eb; padding: 4px 6px; font-size: 12px; color: #111827; }
+      </style>
+    `;
+  }, []);
+
+  // Attach shadow root once
+  useEffect(() => {
+    const host = hostRef.current;
+    if (host && !host.shadowRoot) {
+      const shadow = host.attachShadow({ mode: "open" });
+      setShadowRootRef(shadow);
+    } else if (host && host.shadowRoot && !shadowRootRef) {
+      setShadowRootRef(host.shadowRoot);
+    }
+  }, [shadowRootRef]);
+
+  // Render current value into shadow DOM
+  useEffect(() => {
+    if (!shadowRootRef) return;
+    const content = value ? `${shadowStyles}<div class="excel-container">${value}</div>` : `${shadowStyles}`;
+    // Replace full content each time; simple and safe
+    shadowRootRef.innerHTML = content;
+  }, [shadowRootRef, shadowStyles, value]);
+
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const html = e.clipboardData.getData("text/html");
+    if (!html) {
+      // Only accept HTML table paste
+      return;
+    }
+    // Quick check to ensure table exists in the fragment
+    if (!/\<table[\s\S]*\<\/table\>/i.test(html)) {
+      return;
+    }
+    const sanitized = sanitizeExcelHtmlToSingleTable(html);
+    if (!sanitized) return;
+    onChange(sanitized);
+  }, [onChange]);
+
+  const handleBeforeInput = useCallback((e: React.FormEvent<HTMLDivElement> & { inputType?: string }) => {
+    // Block any typing; allow paste (handled separately) and deletion for clearing
+    // React types don't include inputType on FormEvent; cast via any
+    const event: any = e;
+    const inputType = event.inputType as string | undefined;
+    if (!inputType) return;
+    if (inputType === "insertFromPaste") return; // handled by onPaste
+    if (inputType === "deleteContentBackward" || inputType === "deleteContentForward") return;
+    event.preventDefault?.();
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if ((e.key === "Backspace" || e.key === "Delete")) {
+      e.preventDefault();
+      if (value) onChange("");
+    }
+  }, [onChange, value]);
+
+  const hasContent = Boolean(value && value.trim().length > 0);
+
+  return (
+    <div
+      className={`relative rounded-md border-2 border-dashed border-slate-300 min-h-32 px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-ring ${className || ""}`}
+      onPaste={handlePaste}
+      onKeyDown={handleKeyDown}
+      onBeforeInput={handleBeforeInput as any}
+      // Make it focusable and act like an input target for paste
+      tabIndex={0}
+      role="textbox"
+      aria-label={placeholder || "Excel 표 입력"}
+    >
+      {/* Shadow host renders the isolated table */}
+      <div ref={hostRef} />
+
+      {/* Placeholder */}
+      {!hasContent && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-gray-400">
+          <div className="flex items-center gap-2">
+            <FileSpreadsheet className="h-5 w-5" />
+            <span>{placeholder || "여기에 Excel 표를 붙여넣으세요."}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/client/src/pages/Menu2.tsx
+++ b/client/src/pages/Menu2.tsx
@@ -286,10 +286,22 @@ export default function Menu2() {
       }
     }
 
+    // 의뢰내용에 표1/표2 HTML을 함께 포함시켜 전송
+    const excelSections: string[] = [];
+    if (excelHtml1) {
+      excelSections.push(`<div data-excel-section="1"><p><strong>표1</strong></p>${excelHtml1}</div>`);
+    }
+    if (excelHtml2) {
+      excelSections.push(`<div data-excel-section="2"><p><strong>표2</strong></p>${excelHtml2}</div>`);
+    }
+    const composedContent = excelSections.length > 0
+      ? `${requestContent}${requestContent.trim().endsWith('</p>') ? '' : ''}<p><br></p>${excelSections.join('<p><br></p>')}`
+      : requestContent;
+
     submitRequestMutation.mutate({
       department: selectedDepartment,
       title: requestTitle,
-      content: requestContent,
+      content: composedContent,
       submitted_by: user.username,
       line_id: selectedLineId,
       ppid: selectedPpid,

--- a/client/src/pages/Menu2.tsx
+++ b/client/src/pages/Menu2.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { TestTiptapEditor } from "@/components/TestTiptapEditor";
+import ExcelClipboardBox from "@/components/excel_clipboard_box";
 
 interface EmpInfo {
   id: number;
@@ -204,16 +205,7 @@ export default function Menu2() {
     return partIds;
   };
 
-  // 공통 붙여넣기 핸들러: Excel에서 복사한 표를 HTML로 유지하여 상태에 저장
-  const handlePasteToHtml = (e: React.ClipboardEvent<HTMLDivElement>, setter: (v: string) => void) => {
-    e.preventDefault();
-    const clipboardData = e.clipboardData;
-    const html = clipboardData.getData('text/html');
-    const text = clipboardData.getData('text/plain');
-    // Excel에서 복사하면 보통 text/html로 표가 들어옴. 없으면 텍스트라도 반영
-    const content = html || (text ? `<pre>${text.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>` : '');
-    setter(content);
-  };
+  // 기존 붙여넣기 핸들러는 ExcelClipboardBox로 대체됨
 
   // 의뢰 상신 처리
   const handleSubmitRequest = () => {
@@ -546,37 +538,19 @@ export default function Menu2() {
               <div className="grid grid-cols-1 gap-4">
                 <div>
                   <Label>표1</Label>
-                  <div className="relative">
-                    <div
-                      role="textbox"
-                      contentEditable
-                      onPaste={(e) => handlePasteToHtml(e, setExcelHtml1)}
-                      onInput={(e) => setExcelHtml1((e.target as HTMLDivElement).innerHTML)}
-                      dangerouslySetInnerHTML={{ __html: excelHtml1 }}
-                      className="min-h-32 w-full rounded-md border border-dotted px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      style={{ whiteSpace: 'normal' }}
-                    />
-                    {!excelHtml1 && (
-                      <span className="pointer-events-none absolute left-3 top-2 text-sm text-gray-400">표1을 붙여넣으세요.</span>
-                    )}
-                  </div>
+                  <ExcelClipboardBox
+                    value={excelHtml1}
+                    onChange={setExcelHtml1}
+                    placeholder="표1에 Excel 표를 붙여넣으세요."
+                  />
                 </div>
                 <div>
                   <Label>표2</Label>
-                  <div className="relative">
-                    <div
-                      role="textbox"
-                      contentEditable
-                      onPaste={(e) => handlePasteToHtml(e, setExcelHtml2)}
-                      onInput={(e) => setExcelHtml2((e.target as HTMLDivElement).innerHTML)}
-                      dangerouslySetInnerHTML={{ __html: excelHtml2 }}
-                      className="min-h-32 w-full rounded-md border border-dotted px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                      style={{ whiteSpace: 'normal' }}
-                    />
-                    {!excelHtml2 && (
-                      <span className="pointer-events-none absolute left-3 top-2 text-sm text-gray-400">표2을 붙여넣으세요.</span>
-                    )}
-                  </div>
+                  <ExcelClipboardBox
+                    value={excelHtml2}
+                    onChange={setExcelHtml2}
+                    placeholder="표2에 Excel 표를 붙여넣으세요."
+                  />
                 </div>
               </div>
             )}


### PR DESCRIPTION
Replaced `contentEditable` divs with `ExcelClipboardBox` component to enforce Excel table-only input and ensure independent styling.

The new `ExcelClipboardBox` component uses Shadow DOM to prevent style interference between multiple pasted Excel tables. It also restricts input to only accept HTML table pastes from Excel, blocking plain text input and general typing, and provides a clear visual placeholder with an icon and dashed border.

---
<a href="https://cursor.com/background-agent?bcId=bc-7846e41f-e18d-479c-aea8-e6f6d09d9b4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7846e41f-e18d-479c-aea8-e6f6d09d9b4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

